### PR TITLE
Fix error handling for GitHub Releases

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,6 +18,8 @@ env:
 
 jobs:
   ci:
+    # CI is skipped because `deliver` runs it first anyway
+    if: "github.ref != 'refs/heads/main'"
     runs-on: "ubuntu-latest"
     permissions:
       contents: "read"

--- a/internal/tasks/delivery/run.go
+++ b/internal/tasks/delivery/run.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/opensourcecorp/oscar/internal/consts"
-	igit "github.com/opensourcecorp/oscar/internal/git"
 	iprint "github.com/opensourcecorp/oscar/internal/print"
 	"github.com/opensourcecorp/oscar/internal/tasks/ci"
 	containertools "github.com/opensourcecorp/oscar/internal/tasks/tools/containers"
@@ -64,19 +63,7 @@ func Run(ctx context.Context) (err error) {
 		return fmt.Errorf("internal error setting up run info: %w", err)
 	}
 
-	git, err := igit.New(ctx)
-	if err != nil {
-		return err
-	}
-	iprint.Infof(run.Colors.Gray + git.String() + run.Colors.Reset)
-
-	repo, err := taskutil.NewRepo(ctx)
-	if err != nil {
-		return fmt.Errorf("getting repo composition: %w", err)
-	}
-	iprint.Infof(run.Colors.Gray + repo.String() + run.Colors.Reset)
-
-	taskMap, err := getDeliveryTaskMap(repo)
+	taskMap, err := getDeliveryTaskMap(run.Repo)
 	if err != nil {
 		return err
 	}

--- a/oscar.yaml
+++ b/oscar.yaml
@@ -1,5 +1,5 @@
 ---
-version: "0.3.0-alpha1"
+version: "0.3.0-alpha2"
 deliverables:
   go_github_release:
     build_sources:


### PR DESCRIPTION
`oscar` was returning the wrong `err` variable when checking Go builds, and erroneously saying that a GH Release was successfully created.

This also fixes a small bug where `deliver` was double-printing `git` and `repo` information.